### PR TITLE
Remove tunnel functionality (use Helm's instead)

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "bulk"
-version: "0.0.25"
+version: "0.0.26"
 usage: "Load or Save Helm Releases"
 description: |-
   Load or Save Helm Releases from File to Cluster, or Cluster to File, respectively
@@ -8,3 +8,5 @@ command: "$HELM_PLUGIN_DIR/bin/helm-bulk"
 hooks:
   install: "cd $HELM_PLUGIN_DIR; ./scripts/install.sh"
   update: "cd $HELM_PLUGIN_DIR; ./scripts/install.sh"
+
+useTunnel: true

--- a/utils/client.go
+++ b/utils/client.go
@@ -1,49 +1,31 @@
-/*
-Copyright The Helm Authors.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-/*
-configForContext and getKubeClient funcs copied, at time of writing, from
-https://github.com/helm/helm/blob/1b34a511d4ae38e43518e99a8250330515e3a93c/cmd/helm/helm.go
- without any modifications.
-*/
+// Copyright 2018 OVO Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package utils
 
 import (
-	"fmt"
 	"log"
+	"os"
 
-	"k8s.io/client-go/kubernetes"
-	//https://github.com/helm/helm/issues/3806#issuecomment-378072159
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
 	"k8s.io/helm/pkg/helm"
-	"k8s.io/helm/pkg/helm/portforwarder"
-	kube "k8s.io/helm/pkg/kube"
 	"k8s.io/helm/pkg/tlsutil"
 )
 
 //Client creates a Helm client and checks the connection works
 func Client(tlsKey, tlsCert, caCert, tlsServerName string, disableTLS bool) (client *helm.Client) {
-	config, kclient, err := getKubeClient("", "")
-	PanicCheck(err)
-	log.Println("Portforwarding from Kubernetes Tiller pod")
-	pf, err := portforwarder.New("kube-system", kclient, config)
-	PanicCheck(err)
-	log.Println("Starting Helm client")
-	tillerHost := fmt.Sprintf("127.0.0.1:%d", pf.Local)
 	options := []helm.Option{
-		helm.Host(tillerHost),
+		helm.Host(os.Getenv("TILLER_HOST")),
 	}
 	if !disableTLS {
 		if tlsServerName == "" {
@@ -68,30 +50,4 @@ func Client(tlsKey, tlsCert, caCert, tlsServerName string, disableTLS bool) (cli
 	PanicCheck(errb)
 	log.Println("Connection: OK")
 	return
-}
-
-// configForContext creates a Kubernetes REST client configuration for a
-// given kubeconfig context.
-func configForContext(context string, kubeconfig string) (*rest.Config, error) {
-	config, err := kube.GetConfig(context, kubeconfig).ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("could not get Kubernetes config for context %q: %s",
-			context, err)
-	}
-	return config, nil
-}
-
-// getKubeClient creates a Kubernetes config and client for a given kubeconfig
-// context.
-func getKubeClient(context string, kubeconfig string) (*rest.Config,
-	kubernetes.Interface, error) {
-	config, err := configForContext(context, kubeconfig)
-	if err != nil {
-		return nil, nil, err
-	}
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not get Kubernetes client: %s", err)
-	}
-	return config, client, nil
 }


### PR DESCRIPTION
The licence of `utils/client.go` has been switched from Helm to OVO as there's now nothing in there that's a copy of any Helm source (`configForContext()` and `getKubeClient()` have been removed)

fixes #16 